### PR TITLE
readme: remove ports from sidekiq manual start

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If you want to run the application manually instead of using docker-compose, the
 4. Run the Discourse Sidekiq container:
 
   ```bash
-  $ docker run -d -p 80:3000 --name sidekiq --net=discourse-tier \
+  $ docker run -d --name sidekiq --net=discourse-tier \
       bitnami/discourse nami start --foreground discourse-sidekiq
   ```
 


### PR DESCRIPTION
Starting sidekiq service with port 80 exposed is unnecessary and creates a conflict with subsequent discourse service startup.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
